### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ There already is form method getErrorsAsString(), but it does not provide you wi
 
 **DISCLAIMER**
 --------------
-I wrote this bundle basing on Symfony 2.3.13 for my own purposes, did not tested on other versions, but having in mind what Fabien said about backwards compability, it should work at least on 2.4 and any future relase of Symfony2, as well as on previous versions. Remember that I don't guarantee this, so feel free to test, fork and make your changes.
+I wrote this bundle basing on Symfony 2.3.13 for my own purposes, did not tested on other versions, but having in mind what Fabien said about backwards compatibility, it should work at least on 2.4 and any future relase of Symfony2, as well as on previous versions. Remember that I don't guarantee this, so feel free to test, fork and make your changes.
 
 
 **INSTALLATION**


### PR DESCRIPTION
@Ex3v, I've corrected a typographical error in the documentation of the [FormErrorsBundle](https://github.com/Ex3v/FormErrorsBundle) project. Specifically, I've changed compability to compatibility. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.