### PR TITLE
Update FormErrorsExtension.php

### DIFF
--- a/Twig/FormErrorsExtension.php
+++ b/Twig/FormErrorsExtension.php
@@ -10,6 +10,7 @@ namespace Ex3v\FormErrorsBundle\Twig;
 
 use Symfony\Component\Form\Form;
 use Ex3v\FormErrorsBundle\Services\FormErrorsParser;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FormErrorsExtension extends \Twig_Extension
 {
@@ -20,11 +21,11 @@ class FormErrorsExtension extends \Twig_Extension
      */
     private $parser;
     /**
-     * @var Translator
+     * @var TranslatorInterface 
      */
     private $trans ;
 	
-    public function __construct(FormErrorsParser $parser, Translator $trans)
+    public function __construct(FormErrorsParser $parser, TranslatorInterface $trans)
     {
         $this->parser = $parser;
 		$this->trans =  $trans ;


### PR DESCRIPTION
You have to use TranslatorInterface instead of Translator because symfony 2.7.20 produces an exception:
Catchable Fatal Error: Argument 2 passed to Ex3v\FormErrorsBundle\Twig\FormErrorsExtension::__construct() must be an instance of Ex3v\FormErrorsBundle\Twig\Translator, instance of Symfony\Component\Translation\DataCollectorTranslator given